### PR TITLE
Highlighter

### DIFF
--- a/blueberry/_config.yml
+++ b/blueberry/_config.yml
@@ -1,4 +1,4 @@
-# visit https://github.com/mojombo/jekyll/wiki/Configuration for more settings
+# visit http://jekyllrb.com/docs/configuration/ for more settings
 name: Your New Jekyll Site
 markdown: redcarpet
 highlighter: pygments

--- a/blueberry/_config.yml
+++ b/blueberry/_config.yml
@@ -1,7 +1,7 @@
 # visit https://github.com/mojombo/jekyll/wiki/Configuration for more settings
 name: Your New Jekyll Site
 markdown: redcarpet
-pygments: true
+highlighter: pygments
 paginate: 10 # pagination basted on number of posts
 exclude: ["Gemfile", "Gemfile.lock", "README.md", 'sass', 'watch.sh', 'style.scss', 'bootstrap.scss'] # files to exclude
 

--- a/chocolatechip/_config.yml
+++ b/chocolatechip/_config.yml
@@ -1,4 +1,4 @@
-# visit https://github.com/mojombo/jekyll/wiki/Configuration for more settings
+# visit http://jekyllrb.com/docs/configuration/ for more settings
 name: Your New Jekyll Site
 markdown: redcarpet
 highlighter: pygments

--- a/chocolatechip/_config.yml
+++ b/chocolatechip/_config.yml
@@ -1,7 +1,7 @@
 # visit https://github.com/mojombo/jekyll/wiki/Configuration for more settings
 name: Your New Jekyll Site
 markdown: redcarpet
-pygments: true
+highlighter: pygments
 paginate: 10 # pagination basted on number of posts
 exclude: ["Gemfile", "Gemfile.lock", "README.md", 'sass', 'watch.sh', 'style.scss', 'bootstrap.scss'] # files to exclude
 


### PR DESCRIPTION
I am running jeykll 2.3.0 and I get this warning when running `jeykll serve -w`:

```
$ jekyll serve -w
Configuration file: /home/username/Jekyll/blueberry/_config.yml
       Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
            Source: /home/username/Jekyll/blueberry
       Destination: /home/username/Jekyll/blueberry/_site
      Generating... 
                    done.
 Auto-regeneration: enabled for '/home/username/Jekyll/blueberry'
Configuration file: /home/username/Jekyll/blueberry/_config.yml
       Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
    Server address: http://0.0.0.0:4000/

```

After making the change of `pygments: true` to `highlighter: pygments` in `config.yml` it ran without a warning

```
$ jekyll serve -w
Configuration file: /home/username/Jekyll/blueberry/_config.yml
            Source: /home/username/Jekyll/blueberry
       Destination: /home/username/Jekyll/blueberry/_site
      Generating... 
                    done.
 Auto-regeneration: enabled for '/home/username/Jekyll/blueberry'
Configuration file: /home/username/Jekyll/blueberry/_config.yml
    Server address: http://0.0.0.0:4000/
  Server running... press ctrl-c to stop.
```
